### PR TITLE
[update] added fund class hash to constructor and storage

### DIFF
--- a/contracts/src/fundManager.cairo
+++ b/contracts/src/fundManager.cairo
@@ -20,10 +20,6 @@ mod FundManager {
     use starknet::class_hash::ClassHash;
     use starknet::get_caller_address;
 
-    // This hash will change if fund.cairo file is modified
-    const FUND_CLASS_HASH: felt252 =
-        0x046d36e107b9131c6c1ad0f4ffd473adcadb92c2fe10752718b8c079f95dbb0b;
-
     // *************************************************************************
     //                            STORAGE
     // *************************************************************************
@@ -32,14 +28,16 @@ mod FundManager {
         owner: ContractAddress,
         current_id: u128,
         funds: LegacyMap::<u128, ContractAddress>,
+        fund_class_hash: ClassHash,
     }
 
     // *************************************************************************
     //                            CONSTRUCTOR
     // *************************************************************************
     #[constructor]
-    fn constructor(ref self: ContractState) {
+    fn constructor(ref self: ContractState, fund_class_hash: felt252) {
         self.owner.write(get_caller_address());
+        self.fund_class_hash.write(fund_class_hash.try_into().unwrap());
         self.current_id.write(0);
     }
 
@@ -56,7 +54,7 @@ mod FundManager {
             calldata.append(reason);
             calldata.append(goal.try_into().unwrap());
             let (address_0, _) = deploy_syscall(
-                FUND_CLASS_HASH.try_into().unwrap(), 12345, calldata.span(), false
+                self.fund_class_hash.read(), 12345, calldata.span(), false
             )
                 .unwrap();
             self.funds.write(self.current_id.read(), address_0);


### PR DESCRIPTION
# Pull Request

- [ ] Added tests (if necessary)
Will be implemented in ODHack
- [x] Run tests
- [x] Run formatting
- [x] Commented the code

## Changes description

This PR will add the class hash of the funds contracts to storage so we can call them in the constructor making sure we can deploy the contract using the desired class hash.

## Current output

Not necessary


