### PR TITLE
[fix] Using ByteArray to represent reason

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -6,8 +6,8 @@ pub trait IFund<TContractState> {
     fn getOwner(self: @TContractState) -> ContractAddress;
     fn setName(ref self: TContractState, name: felt252);
     fn getName(self: @TContractState) -> felt252;
-    fn setReason(ref self: TContractState, reason: felt252);
-    fn getReason(self: @TContractState) -> felt252;
+    fn setReason(ref self: TContractState, reason: ByteArray);
+    fn getReason(self: @TContractState) -> ByteArray;
     fn receiveVote(ref self: TContractState);
     fn getUpVotes(self: @TContractState) -> u32;
     fn setGoal(ref self: TContractState, goal: u64);
@@ -38,7 +38,7 @@ mod Fund {
         id: u128,
         owner: ContractAddress,
         name: felt252,
-        reason: felt252,
+        reason: ByteArray,
         up_votes: u32,
         voters: LegacyMap::<ContractAddress, u32>,
         goal: u64,
@@ -51,17 +51,12 @@ mod Fund {
     // *************************************************************************
     #[constructor]
     fn constructor(
-        ref self: ContractState,
-        id: u128,
-        owner: ContractAddress,
-        name: felt252,
-        reason: felt252,
-        goal: u64
+        ref self: ContractState, id: u128, owner: ContractAddress, name: felt252, goal: u64
     ) {
         self.id.write(id);
         self.owner.write(owner);
         self.name.write(name);
-        self.reason.write(reason);
+        self.reason.write(" ");
         self.up_votes.write(FundConstants::INITIAL_UP_VOTES);
         self.goal.write(goal);
         self.current_goal_state.write(FundConstants::INITIAL_GOAL);
@@ -87,12 +82,12 @@ mod Fund {
         fn getName(self: @ContractState) -> felt252 {
             return self.name.read();
         }
-        fn setReason(ref self: ContractState, reason: felt252) {
+        fn setReason(ref self: ContractState, reason: ByteArray) {
             let caller = get_caller_address();
             assert!(self.owner.read() == caller, "You are not the owner");
             self.reason.write(reason);
         }
-        fn getReason(self: @ContractState) -> felt252 {
+        fn getReason(self: @ContractState) -> ByteArray {
             return self.reason.read();
         }
         fn receiveVote(ref self: ContractState) {

--- a/contracts/src/fundManager.cairo
+++ b/contracts/src/fundManager.cairo
@@ -3,7 +3,7 @@ use starknet::class_hash::ClassHash;
 
 #[starknet::interface]
 pub trait IFundManager<TContractState> {
-    fn newFund(ref self: TContractState, name: felt252, reason: felt252, goal: u64);
+    fn newFund(ref self: TContractState, name: felt252, goal: u64);
     fn getCurrentId(self: @TContractState) -> u128;
     fn getFund(self: @TContractState, id: u128) -> ContractAddress;
 }
@@ -46,12 +46,11 @@ mod FundManager {
     // *************************************************************************
     #[abi(embed_v0)]
     impl FundManagerImpl of super::IFundManager<ContractState> {
-        fn newFund(ref self: ContractState, name: felt252, reason: felt252, goal: u64) {
+        fn newFund(ref self: ContractState, name: felt252, goal: u64) {
             let mut calldata = ArrayTrait::<felt252>::new();
             calldata.append(self.current_id.read().try_into().unwrap());
             calldata.append(get_caller_address().try_into().unwrap());
             calldata.append(name);
-            calldata.append(reason);
             calldata.append(goal.try_into().unwrap());
             let (address_0, _) = deploy_syscall(
                 self.fund_class_hash.read(), 12345, calldata.span(), false

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -1,6 +1,6 @@
-// *************************************************************************
+// *************************
 //                              FUND TEST
-// *************************************************************************
+// *************************
 use starknet::{ContractAddress, contract_address_const};
 
 use snforge_std::{declare, ContractClassTrait, CheatTarget};
@@ -22,28 +22,27 @@ fn OTHER_USER() -> ContractAddress {
 fn NAME() -> felt252 {
     'NAME_FUND_TEST'
 }
-fn REASON() -> felt252 {
-    'REASON_FUND_TEST'
+fn REASON() -> ByteArray {
+    "Lorem impsum, Lorem impsum, Lorem impsum, Lorem impsum, Lorem impsum, Lorem impsum, Lorem impsum, Lorem impsum"
 }
 fn GOAL() -> u64 {
     1000
 }
-fn __setup__() -> ContractAddress {
+fn _setup_() -> ContractAddress {
     let contract = declare("Fund");
     let mut calldata: Array<felt252> = array![];
     calldata.append_serde(ID());
     calldata.append_serde(OWNER());
     calldata.append_serde(NAME());
-    calldata.append_serde(REASON());
     calldata.append_serde(GOAL());
     contract.deploy(@calldata).unwrap()
 }
-// *************************************************************************
+// *************************
 //                              TEST
-// *************************************************************************
+// *************************
 #[test]
 fn test_constructor() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let id = dispatcher.getId();
     let owner = dispatcher.getOwner();
@@ -56,7 +55,7 @@ fn test_constructor() {
     assert(id == ID(), 'Invalid id');
     assert(owner == OWNER(), 'Invalid owner');
     assert(name == NAME(), 'Invalid name');
-    assert(reason == REASON(), 'Invalid reason');
+    assert(reason == " ", 'Invalid reason');
     assert(up_votes == 0, 'Invalid up votes');
     assert(goal == GOAL(), 'Invalid goal');
     assert(current_goal_state == 0, 'Invalid current goal state');
@@ -65,7 +64,7 @@ fn test_constructor() {
 
 #[test]
 fn test_set_name() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let name = dispatcher.getName();
     assert(name == NAME(), 'Invalid name');
@@ -77,19 +76,19 @@ fn test_set_name() {
 
 #[test]
 fn test_set_reason() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let reason = dispatcher.getReason();
-    assert(reason == REASON(), 'Invalid reason');
+    assert(reason == " ", 'Invalid reason');
     snforge_std::start_prank(CheatTarget::One(contract_address), OWNER());
-    dispatcher.setReason('NEW_REASON');
+    dispatcher.setReason(REASON());
     let new_reason = dispatcher.getReason();
-    assert(new_reason == 'NEW_REASON', 'Set reason method not working')
+    assert(new_reason == REASON(), 'Set reason method not working')
 }
 
 #[test]
 fn test_set_goal() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let goal = dispatcher.getGoal();
     assert(goal == GOAL(), 'Invalid goal');
@@ -101,7 +100,7 @@ fn test_set_goal() {
 
 #[test]
 fn test_receive_vote_successful() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     dispatcher.receiveVote();
     let me = dispatcher.getVoter();
@@ -114,7 +113,7 @@ fn test_receive_vote_successful() {
 #[test]
 #[should_panic(expected: ('User already voted!',))]
 fn test_receive_vote_unsuccessful_double_vote() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     dispatcher.receiveVote();
     let me = dispatcher.getVoter();
@@ -128,7 +127,7 @@ fn test_receive_vote_unsuccessful_double_vote() {
 
 #[test]
 fn test_receive_donation_successful() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     // Put state as recollecting dons
     dispatcher.setIsActive(2);
@@ -148,7 +147,7 @@ fn test_receive_donation_successful() {
 #[test]
 #[should_panic(expected: ('Fund not recollecting dons!',))]
 fn test_receive_donation_unsuccessful_wrong_state() {
-    let contract_address = __setup__();
+    let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     // Put a wrong state to receive donations
     dispatcher.setIsActive(1);


### PR DESCRIPTION
# Pull Request

- [x] Closes #75 
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [x] Commented the code

## Changes description

This will change the fund contract to use ByteArray for reason and not sending the reason when deploying a fund.