### PR TITLE
refactor: change data types to handle ERC20 tokens

### DIFF
--- a/contracts/src/constants/donator/donator_constants.cairo
+++ b/contracts/src/constants/donator/donator_constants.cairo
@@ -3,5 +3,5 @@
 // *************************************************************************
 pub mod DonatorConstants {
     pub const INITIAL_LEVEL: u32 = 1;
-    pub const INITIAL_MAX_STARKS_DONATION_TO_NEXT_LEVEL: u64 = 10;
+    pub const INITIAL_MAX_STARKS_DONATION_TO_NEXT_LEVEL: u256 = 10;
 }

--- a/contracts/src/constants/funds/fund_constants.cairo
+++ b/contracts/src/constants/funds/fund_constants.cairo
@@ -5,4 +5,5 @@ pub mod FundConstants {
     pub const UP_VOTES_NEEDED: u32 = 100;
     pub const INITIAL_UP_VOTES: u32 = 0;
     pub const INITIAL_GOAL: u256 = 0;
+    pub const STRK_TOKEN_ADDRESS: felt252 = 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
 }

--- a/contracts/src/constants/funds/fund_constants.cairo
+++ b/contracts/src/constants/funds/fund_constants.cairo
@@ -4,5 +4,5 @@
 pub mod FundConstants {
     pub const UP_VOTES_NEEDED: u32 = 100;
     pub const INITIAL_UP_VOTES: u32 = 0;
-    pub const INITIAL_GOAL: u64 = 0;
+    pub const INITIAL_GOAL: u256 = 0;
 }

--- a/contracts/src/donator.cairo
+++ b/contracts/src/donator.cairo
@@ -4,9 +4,9 @@ use starknet::ContractAddress;
 pub trait IDonator<TContractState> {
     fn getOwner(self: @TContractState) -> ContractAddress;
     fn getLevel(self: @TContractState) -> u32;
-    fn getTotalStarkDonations(self: @TContractState) -> u64;
-    fn getMaxStarkDonationsToNextLevel(self: @TContractState) -> u64;
-    fn updateDonatorValues(ref self: TContractState, donated_starks: u64);
+    fn getTotalStarkDonations(self: @TContractState) -> u256;
+    fn getMaxStarkDonationsToNextLevel(self: @TContractState) -> u256;
+    fn updateDonatorValues(ref self: TContractState, donated_starks: u256);
 }
 
 #[starknet::contract]
@@ -24,8 +24,8 @@ mod Donator {
     struct Storage {
         owner: ContractAddress,
         level: u32,
-        total_stark_donations: u64,
-        max_stark_donations_to_next_level: u64
+        total_stark_donations: u256,
+        max_stark_donations_to_next_level: u256
     }
 
     // *************************************************************************
@@ -52,13 +52,13 @@ mod Donator {
         fn getLevel(self: @ContractState) -> u32 {
             return self.level.read();
         }
-        fn getTotalStarkDonations(self: @ContractState) -> u64 {
+        fn getTotalStarkDonations(self: @ContractState) -> u256 {
             return self.total_stark_donations.read();
         }
-        fn getMaxStarkDonationsToNextLevel(self: @ContractState) -> u64 {
+        fn getMaxStarkDonationsToNextLevel(self: @ContractState) -> u256 {
             return self.max_stark_donations_to_next_level.read();
         }
-        fn updateDonatorValues(ref self: ContractState, donated_starks: u64) {
+        fn updateDonatorValues(ref self: ContractState, donated_starks: u256) {
             let total_donator_pod = self.total_stark_donations.read() + donated_starks;
             self.total_stark_donations.write(total_donator_pod);
             if (total_donator_pod > self.max_stark_donations_to_next_level.read()) {

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -26,6 +26,7 @@ mod Fund {
     // *************************************************************************
     use starknet::ContractAddress;
     use starknet::get_caller_address;
+    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use gostarkme::constants::{funds::{state_constants::FundStates},};
     use gostarkme::constants::{funds::{fund_constants::FundConstants},};
 
@@ -43,7 +44,7 @@ mod Fund {
         voters: LegacyMap::<ContractAddress, u32>,
         goal: u256,
         current_goal_state: u256,
-        state: u8
+        state: u8,
     }
 
     // *************************************************************************

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -10,10 +10,10 @@ pub trait IFund<TContractState> {
     fn getReason(self: @TContractState) -> ByteArray;
     fn receiveVote(ref self: TContractState);
     fn getUpVotes(self: @TContractState) -> u32;
-    fn setGoal(ref self: TContractState, goal: u64);
-    fn getGoal(self: @TContractState) -> u64;
-    fn receiveDonation(ref self: TContractState, strks: u64);
-    fn getCurrentGoalState(self: @TContractState) -> u64;
+    fn setGoal(ref self: TContractState, goal: u256);
+    fn getGoal(self: @TContractState) -> u256;
+    fn receiveDonation(ref self: TContractState, strks: u256);
+    fn getCurrentGoalState(self: @TContractState) -> u256;
     fn setIsActive(ref self: TContractState, state: u8);
     fn getIsActive(self: @TContractState) -> u8;
     fn getVoter(self: @TContractState) -> u32;
@@ -41,8 +41,8 @@ mod Fund {
         reason: ByteArray,
         up_votes: u32,
         voters: LegacyMap::<ContractAddress, u32>,
-        goal: u64,
-        current_goal_state: u64,
+        goal: u256,
+        current_goal_state: u256,
         state: u8
     }
 
@@ -51,7 +51,7 @@ mod Fund {
     // *************************************************************************
     #[constructor]
     fn constructor(
-        ref self: ContractState, id: u128, owner: ContractAddress, name: felt252, goal: u64
+        ref self: ContractState, id: u128, owner: ContractAddress, name: felt252, goal: u256
     ) {
         self.id.write(id);
         self.owner.write(owner);
@@ -104,16 +104,16 @@ mod Fund {
         fn getUpVotes(self: @ContractState) -> u32 {
             return self.up_votes.read();
         }
-        fn setGoal(ref self: ContractState, goal: u64) {
+        fn setGoal(ref self: ContractState, goal: u256) {
             let caller = get_caller_address();
             assert!(self.owner.read() == caller, "You are not the owner");
             self.goal.write(goal);
         }
-        fn getGoal(self: @ContractState) -> u64 {
+        fn getGoal(self: @ContractState) -> u256 {
             return self.goal.read();
         }
         // TODO: implement the logic where user actually donates starks
-        fn receiveDonation(ref self: ContractState, strks: u64) {
+        fn receiveDonation(ref self: ContractState, strks: u256) {
             assert(
                 self.state.read() == FundStates::RECOLLECTING_DONATIONS,
                 'Fund not recollecting dons!'
@@ -123,7 +123,7 @@ mod Fund {
                 self.state.write(FundStates::CLOSED);
             }
         }
-        fn getCurrentGoalState(self: @ContractState) -> u64 {
+        fn getCurrentGoalState(self: @ContractState) -> u256 {
             return self.current_goal_state.read();
         }
         // TODO: Validate to change method to change setState and getState


### PR DESCRIPTION
# Pull Request

Closes #129 

## Changes description

Modify the data types across smart contracts and constants to `u256` to handle ERC20 token transactions

## Comments

Necessary refactor to start working on #120 and #121 properly.
