### PR TITLE
[feat] Emit event when user withdraw fund's balance

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -34,6 +34,23 @@ mod Fund {
     use gostarkme::constants::{funds::{fund_constants::FundConstants},};
     use gostarkme::constants::{funds::{starknet_constants::StarknetConstants},};
 
+    // *************************************************************************
+    //                            EVENTS
+    // *************************************************************************
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        DonationWithdraw: DonationWithdraw,
+    }
+    // Struct DonationWithdraw
+    #[derive(Drop, starknet::Event)]
+    struct DonationWithdraw {
+        #[key]
+        fund_contract_address: ContractAddress,
+        owner_address: ContractAddress,
+        withdrawn_amount: u256
+    }
 
     // *************************************************************************
     //                            STORAGE

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -174,6 +174,12 @@ mod Fund {
             //TODO: Calculate balance to deposit in owner address and in fund manager address (95% and 5%), also transfer the amount to fund manager address.
             starknet_dispatcher.transfer(self.getOwner(), balance);
             assert(self.getCurrentGoalState() != 0, 'Fund hasnt reached its goal yet');
+            // Emit Event DonationWithdraw (amount=balance)
+            self.emit(DonationWithdraw {
+                fund_contract_address: get_contract_address(),
+                owner_address: self.getOwner(),
+                withdrawn_amount: balance
+            });
             self.setState(4);
         }
     }

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -48,6 +48,7 @@ mod Fund {
     pub struct DonationWithdraw {
         #[key]
         pub owner_address: ContractAddress,
+        pub fund_contract_address: ContractAddress,
         pub withdrawn_amount: u256
     }
 
@@ -173,12 +174,13 @@ mod Fund {
             //TODO: Calculate balance to deposit in owner address and in fund manager address (95% and 5%), also transfer the amount to fund manager address.
             starknet_dispatcher.transfer(self.getOwner(), balance);
             assert(self.getCurrentGoalState() != 0, 'Fund hasnt reached its goal yet');
+            self.setState(4);
             // Emit Event DonationWithdraw (amount=balance)
             self.emit(DonationWithdraw {
                 owner_address: self.getOwner(),
+                fund_contract_address: get_contract_address(),
                 withdrawn_amount: balance
             });
-            self.setState(4);
         }
     }
 }

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -45,11 +45,10 @@ mod Fund {
     }
     // Struct DonationWithdraw
     #[derive(Drop, starknet::Event)]
-    struct DonationWithdraw {
+    pub struct DonationWithdraw {
         #[key]
-        fund_contract_address: ContractAddress,
-        owner_address: ContractAddress,
-        withdrawn_amount: u256
+        pub owner_address: ContractAddress,
+        pub withdrawn_amount: u256
     }
 
     // *************************************************************************
@@ -176,7 +175,6 @@ mod Fund {
             assert(self.getCurrentGoalState() != 0, 'Fund hasnt reached its goal yet');
             // Emit Event DonationWithdraw (amount=balance)
             self.emit(DonationWithdraw {
-                fund_contract_address: get_contract_address(),
                 owner_address: self.getOwner(),
                 withdrawn_amount: balance
             });


### PR DESCRIPTION
# Pull Request

- [x] Closes #139 
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Commented the code

## Changes description

This PR adds `DonationWithdraw` event for `fn withdraw` in `fund.cairo` file, using `owner_address` as the key and `withdrawn_amount` as the data.

## Current output

The example output is:

```
"events": [
    {
      "from_address": "0x27d07155a12554d4fd785d0b6d80c03e433313df03bb57939ec8fb0652dbe79", //Contract Address
      "keys": [
        "0x426f6f6b4164646564",  // selector!("DonationWithdraw")
        "0x27d070b6db5703e433313df0939ec8fb0680c155a12554d4fd785d3b52dbe79" // Owner address
      ],
      "data": [
        "0x208b7fff7fff7ffe", //withdrawn_amount (u256 STRK)
      ]
    }
  ]
```

Where: 

- first key =  `selector!("DonationWithdraw")`
- second key = `Owner address`
- data = `withdrawn_amount`

Event Struct: 
```
    pub struct DonationWithdraw {
        #[key]
        pub owner_address: ContractAddress,
        pub withdrawn_amount: u256
    }
```

## Time spent breakdown

2 hours aprox spent

## Comments

I look forward to any comments or questions.


