### PR TITLE
Fund test event emit

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -21,7 +21,7 @@ pub trait IFund<TContractState> {
 }
 
 #[starknet::contract]
-mod Fund {
+pub mod Fund {
     // *************************************************************************
     //                            IMPORT
     // *************************************************************************
@@ -41,7 +41,7 @@ mod Fund {
     // *************************************************************************
     #[event]
     #[derive(Drop, starknet::Event)]
-    enum Event {
+    pub enum Event {
         DonationWithdraw: DonationWithdraw,
         NewVoteReceived: NewVoteReceived,
         DonationReceived: DonationReceived,


### PR DESCRIPTION
# Pull Request

-  Closes #145 
-  Added tests: test_new_vote_received_event_emitted_successful

## Changes:

This adds a test to verify that the NewVoteReceived event is correctly emitted when a user votes. It checks that the event includes the right voter address, fund address, and vote count.

## Current output:

![image](https://github.com/user-attachments/assets/03da50a9-87c4-4b4a-87b2-731ca6017a58)

