### PR TITLE
fix: delete Latest funds header and add margin to funds section

### DIFF
--- a/frontend/gostarkme-web/app/app/page.tsx
+++ b/frontend/gostarkme-web/app/app/page.tsx
@@ -64,17 +64,13 @@ const Dashboard = () => {
           href: "/"
         }}
       />
-      <h1 className="text-3xl font-bold ml-30 mb-6 flex items-center self-start m-10 ml-28">
-        Latest Funds
-        <span className="ml-2 text-yellow-400">&#x2728;</span>
-      </h1>
 
-      {loading && <div className="text-center text-gray-500">
+      {loading && <div className="text-center text-gray-500 mt-12">
         Loading funds ...
       </div>}
 
       {funds.length !== 0 && !loading &&
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6 md:gap-x-[138px] md:gap-y-[84px]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6 md:gap-x-[138px] md:gap-y-[84px] mt-10 lg:mt-12">
           {funds.map((fund: { type: string; title: string; description: string; fund_id: string }, index: number) => (
             <FundCards key={index} fund={fund} index={index} />
           ))}


### PR DESCRIPTION
# Pull Request

- [x] Closes #186
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Commented the code

## Changes description

- Deleted the `<h1>` tag containing `"Latest Funds"`.
- Added some margin to the `funds` section and `Loading funds` div

## Current output
![Screenshot (28)](https://github.com/user-attachments/assets/13e2a5a3-dcdb-4e9c-8d64-bef01ddfd5c1)


## Time spent breakdown

Took a few minutes to write the code.

## Comments

@all-contributors please add @wheval for code

The `npm run lint` failed to run.
