### PR TITLE
[feat] Add asserts to set_name

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -130,7 +130,13 @@ pub mod Fund {
         }
         fn set_name(ref self: ContractState, name: ByteArray) {
             let caller = get_caller_address();
-            assert!(self.owner.read() == caller, "You are not the owner");
+            let valid_address_1 = contract_address_const::<
+                FundManagerConstants::VALID_ADDRESS_1
+            >();
+            let valid_address_2 = contract_address_const::<
+                FundManagerConstants::VALID_ADDRESS_2
+            >();
+            assert!(valid_address_1 == caller || valid_address_2 == caller, "You are not the admin");
             self.name.write(name);
         }
         fn get_name(self: @ContractState) -> ByteArray {

--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -136,7 +136,9 @@ pub mod Fund {
             let valid_address_2 = contract_address_const::<
                 FundManagerConstants::VALID_ADDRESS_2
             >();
-            assert!(valid_address_1 == caller || valid_address_2 == caller, "You are not the admin");
+            assert!(
+                self.owner.read() == caller || valid_address_1 == caller || valid_address_2 == caller,
+                "You must be an owner or admin to perform this action");
             self.name.write(name);
         }
         fn get_name(self: @ContractState) -> ByteArray {

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -60,6 +60,9 @@ fn CONTACT_HANDLE_2() -> ByteArray {
 fn VALID_ADDRESS_1() -> ContractAddress {
     contract_address_const::<FundManagerConstants::VALID_ADDRESS_1>()
 }
+fn VALID_ADDRESS_2() -> ContractAddress {
+    contract_address_const::<FundManagerConstants::VALID_ADDRESS_2>()
+}
 fn _setup_() -> ContractAddress {
     let contract = declare("Fund").unwrap();
     let mut calldata: Array<felt252> = array![];
@@ -101,6 +104,23 @@ fn test_constructor() {
 
 #[test]
 fn test_set_name() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    let name = dispatcher.get_name();
+    assert(name == NAME(), 'Invalid name');
+
+    start_cheat_caller_address_global(VALID_ADDRESS_1());
+    dispatcher.set_name("NEW_NAME_1");
+    assert(dispatcher.get_name() == "NEW_NAME_1", 'Set name method not working');
+
+    start_cheat_caller_address_global(VALID_ADDRESS_2());
+    dispatcher.set_name("NEW_NAME_2");
+    assert(dispatcher.get_name() == "NEW_NAME_2", 'Set name method not working');
+}
+
+#[test]
+#[should_panic(expected: ("You are not the admin",))]
+fn test_set_name_not_admin() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let name = dispatcher.get_name();

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -103,32 +103,46 @@ fn test_constructor() {
 }
 
 #[test]
-fn test_set_name() {
+fn test_set_name_admin() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let name = dispatcher.get_name();
     assert(name == NAME(), 'Invalid name');
 
     start_cheat_caller_address_global(VALID_ADDRESS_1());
-    dispatcher.set_name("NEW_NAME_1");
-    assert(dispatcher.get_name() == "NEW_NAME_1", 'Set name method not working');
+    dispatcher.set_name("NEW_NAME_ADMIN_1");
+    assert(dispatcher.get_name() == "NEW_NAME_ADMIN_1", 'Set name method not working');
 
     start_cheat_caller_address_global(VALID_ADDRESS_2());
-    dispatcher.set_name("NEW_NAME_2");
-    assert(dispatcher.get_name() == "NEW_NAME_2", 'Set name method not working');
+    dispatcher.set_name("NEW_NAME_ADMIN_2");
+    assert(dispatcher.get_name() == "NEW_NAME_ADMIN_2", 'Set name method not working');
 }
 
 #[test]
-#[should_panic(expected: ("You are not the admin",))]
-fn test_set_name_not_admin() {
+fn test_set_name_owner() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let name = dispatcher.get_name();
     assert(name == NAME(), 'Invalid name');
+
     start_cheat_caller_address_global(OWNER());
     dispatcher.set_name("NEW_NAME");
     let new_name = dispatcher.get_name();
-    assert(new_name == "NEW_NAME", 'Set name method not working')
+    assert(new_name == "NEW_NAME", 'Set name method not working');
+}
+
+#[test]
+#[should_panic(expected: ("You must be an owner or admin to perform this action",))]
+fn test_set_name_not_admin_or_owner() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    let name = dispatcher.get_name();
+    assert(name == NAME(), 'Invalid name');
+
+    start_cheat_caller_address_global(FUND_MANAGER());
+    dispatcher.set_name("NEW_NAME");
+    let new_name = dispatcher.get_name();
+    assert(new_name == "NEW_NAME", 'Set name method not working');
 }
 
 #[test]


### PR DESCRIPTION
# Pull Request

- [ ] Closes #
- [ X] Added tests (if necessary)
- [ X] Run tests
- [ ] Run formatting
- [ ] Commented the code

## Changes description

1. Locate the set_name function in contracts/src/fund.cairo and enhance it by adding validation to ensure the caller is either VALID_ADDRESS_1 or VALID_ADDRESS_2.
2. Add a test to verify that the set_name function works correctly when called by VALID_ADDRESS_1 or VALID_ADDRESS_2.
3. Add a test to confirm that the set_name function does not work when called by an address other than VALID_ADDRESS_1 or VALID_ADDRESS_2.

## Current output

![Screenshot from 2024-11-22 10-54-04](https://github.com/user-attachments/assets/d4cdd544-3cf9-4baf-86d9-c5d105649d6a)

## Time spent breakdown

2 hours.

## Comments

Thank you for the opportunity to contribute to this great project
