### PR TITLE
Feat: Assert-set-contact-handle

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -252,7 +252,14 @@ pub mod Fund {
         }
         fn set_contact_handle(ref self: ContractState, contact_handle: ByteArray) {
             let caller = get_caller_address();
-            assert!(self.owner.read() == caller, "You are not the owner");
+            let valid_address_1 = contract_address_const::<FundManagerConstants::VALID_ADDRESS_1>();
+            let valid_address_2 = contract_address_const::<FundManagerConstants::VALID_ADDRESS_2>();
+            assert!(
+                self.owner.read() == caller
+                    || valid_address_1 == caller
+                    || valid_address_2 == caller,
+                "You must be an owner or admin to perform this action"
+            );
             self.contact_handle.write(contact_handle);
         }
         fn get_contact_handle(self: @ContractState) -> ByteArray {

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -60,6 +60,9 @@ fn CONTACT_HANDLE_2() -> ByteArray {
 fn VALID_ADDRESS_1() -> ContractAddress {
     contract_address_const::<FundManagerConstants::VALID_ADDRESS_1>()
 }
+fn VALID_ADDRESS_2() -> ContractAddress {
+    contract_address_const::<FundManagerConstants::VALID_ADDRESS_2>()
+}
 fn _setup_() -> ContractAddress {
     let contract = declare("Fund").unwrap();
     let mut calldata: Array<felt252> = array![];
@@ -310,7 +313,7 @@ fn test_set_evidence_link_wrong_owner() {
 }
 
 #[test]
-fn test_set_contact_handle() {
+fn test_set_contact_handle_owner() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let contact_handle = dispatcher.get_contact_handle();
@@ -322,8 +325,32 @@ fn test_set_contact_handle() {
 }
 
 #[test]
-#[should_panic(expected: ("You are not the owner",))]
-fn test_set_contact_handle_wrong_owner() {
+fn test_set_contact_handle_admin_1() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    let contact_handle = dispatcher.get_contact_handle();
+    assert(contact_handle == CONTACT_HANDLE_1(), 'Invalid contact handle');
+    start_cheat_caller_address_global(VALID_ADDRESS_1());
+    dispatcher.set_contact_handle(CONTACT_HANDLE_2());
+    let new_contact_handle = dispatcher.get_contact_handle();
+    assert(new_contact_handle == CONTACT_HANDLE_2(), 'Set contact method not working')
+}
+
+#[test]
+fn test_set_contact_handle_admin_2() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    let contact_handle = dispatcher.get_contact_handle();
+    assert(contact_handle == CONTACT_HANDLE_1(), 'Invalid contact handle');
+    start_cheat_caller_address_global(VALID_ADDRESS_2());
+    dispatcher.set_contact_handle(CONTACT_HANDLE_2());
+    let new_contact_handle = dispatcher.get_contact_handle();
+    assert(new_contact_handle == CONTACT_HANDLE_2(), 'Set contact method not working')
+}
+
+#[test]
+#[should_panic(expected: ("You must be an owner or admin to perform this action",))]
+fn test_set_contact_handle_wrong_owner_or_admin() {
     let contract_address = _setup_();
     start_cheat_caller_address_global(OTHER_USER());
     IFundDispatcher { contract_address }.set_contact_handle(CONTACT_HANDLE_2());


### PR DESCRIPTION
# Pull Request

- [ ] Closes #255
- [X] Added tests (if necessary)
- [X] Run tests
- [X] Run formatting
- [ ] Commented the code

## Changes description

Locate the set_contact_handle function in contracts/src/fund.cairo and enhance it by adding validation to ensure the caller is either VALID_ADDRESS_1 or VALID_ADDRESS_2.
Add a test to verify that the set_contact_handle function works correctly when called by VALID_ADDRESS_1 and another for VALID_ADDRESS_2.

## Current output

![Captura de pantalla 2024-11-24 140837](https://github.com/user-attachments/assets/932592a8-2cc6-4a96-a911-d25089f0fdf8)

## Time spent breakdown

1 hour

## Comments

Thank you for letting me contribute to the project.
