### PR TITLE
fix: Add new asserts to set_goal

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -177,10 +177,12 @@ pub mod Fund {
         }
         fn set_goal(ref self: ContractState, goal: u256) {
             let caller = get_caller_address();
-            let fund_manager_address = contract_address_const::<
-                FundManagerConstants::FUND_MANAGER_ADDRESS
-            >();
-            assert!(fund_manager_address == caller, "You are not the fund manager");
+            let valid_address_1 = contract_address_const::<FundManagerConstants::VALID_ADDRESS_1>();
+            let valid_address_2 = contract_address_const::<FundManagerConstants::VALID_ADDRESS_2>();
+            assert!(
+                valid_address_1 == caller || valid_address_2 == caller,
+                "Only Admins can change the fund state"
+            );
             self.goal.write(goal);
         }
         fn get_goal(self: @ContractState) -> u256 {

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -163,10 +163,16 @@ fn test_set_goal() {
     let dispatcher = IFundDispatcher { contract_address };
     let goal = dispatcher.get_goal();
     assert(goal == GOAL(), 'Invalid goal');
-    start_cheat_caller_address_global(FUND_MANAGER());
+    
+    start_cheat_caller_address_global(VALID_ADDRESS_1());
     dispatcher.set_goal(123);
     let new_goal = dispatcher.get_goal();
     assert(new_goal == 123, 'Set goal method not working')
+
+    start_cheat_caller_address_global(VALID_ADDRESS_2());
+    dispatcher.set_goal(140);
+    let new_goal_2 = dispatcher.get_goal();
+    assert(new_goal_2 == 140, 'Set goal method not working');
 }
 
 #[test]
@@ -222,7 +228,7 @@ fn test_new_vote_received_event_emitted_successful() {
 }
 
 #[test]
-#[should_panic(expected: ("You are not the fund manager",))]
+#[should_panic(expected: ("Only Admins can change the fund state",))]
 fn test_set_goal_unauthorized() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };


### PR DESCRIPTION
# Pull Request

- [x] Closes #254
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting

## Changes description
-I remove assert where the fund manager can call the method set_method
-I add new assert that validate that the caller should be the admins in set_goal method in contracts/src/fund.cairo using the two  admins (VALID_ADDRESS_1,VALID_ADDRESS_2) constants located in contracts/src/constants/funds/fund_manager_constants.cairo

## Current output
![Screenshot_20241125_043512](https://github.com/user-attachments/assets/e169b50b-7b46-4117-b49a-e71dd872ebaa)


## Time spent breakdown
less than 24 hours, which is due to some installation issue on window

## Comments

None, 
Thanks
