### PR TITLE
[test] Add test for new assert in set_name method

### DIFF
--- a/contracts/src/fund.cairo
+++ b/contracts/src/fund.cairo
@@ -149,7 +149,9 @@ pub mod Fund {
             let valid_address_2 = contract_address_const::<FundManagerConstants::VALID_ADDRESS_2>();
 
             assert!(
-                self.owner.read() == caller || valid_address_1 == caller || valid_address_2 == caller,
+                self.owner.read() == caller
+                    || valid_address_1 == caller
+                    || valid_address_2 == caller,
                 "You must be an owner or admin to perform this action"
             );
 

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -133,6 +133,18 @@ fn test_set_name_owner() {
 
 #[test]
 #[should_panic(expected: ("You must be an owner or admin to perform this action",))]
+fn test_set_name_unauthorized_access() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    let name = dispatcher.get_name();
+    assert(name == NAME(), "Invalid name");
+
+    start_cheat_caller_address_global(OTHER_USER());
+    dispatcher.set_name("UNAUTHORIZED_NAME");
+}
+
+#[test]
+#[should_panic(expected: ("You must be an owner or admin to perform this action",))]
 fn test_set_name_not_admin_or_owner() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -137,7 +137,7 @@ fn test_set_name_unauthorized_access() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
     let name = dispatcher.get_name();
-    assert(name == NAME(), "Invalid name");
+    assert(name == NAME(), 'Invalid name');
 
     start_cheat_caller_address_global(OTHER_USER());
     dispatcher.set_name("UNAUTHORIZED_NAME");
@@ -600,5 +600,4 @@ fn test_set_contact_handle_success() {
     let reverted_contact_handle = dispatcher.get_contact_handle();
     assert(reverted_contact_handle == CONTACT_HANDLE_1(), ' revert ')
 }
-
 


### PR DESCRIPTION
### What does this PR do?
Adds a unit test to validate the new assert in the `set_name` method.

### Why is this change necessary?
To ensure the assert behaves as expected and improves reliability for future changes.

### How was this tested?
- Ran `snforge test` to confirm the test passes.
![image](https://github.com/user-attachments/assets/3c4125d9-51f0-4042-b7e7-729a2b601130)

### Related Issue
Fixes: #256
