### PR TITLE
[test] add new set_goal test

### DIFF
--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -191,21 +191,31 @@ fn test_set_reason_admins() {
 }
 
 #[test]
-fn test_set_goal() {
+fn test_set_goal_by_admins() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
-    let goal = dispatcher.get_goal();
-    assert(goal == GOAL(), 'Invalid goal');
+
+    let initial_goal = dispatcher.getGoal();
+    assert(initial_goal == GOAL(), 'Initial goal is incorrect');
 
     start_cheat_caller_address_global(VALID_ADDRESS_1());
-    dispatcher.set_goal(123);
-    let new_goal = dispatcher.get_goal();
-    assert(new_goal == 123, 'Set goal method not working');
+    dispatcher.setGoal(123);
+    let updated_goal_1 = dispatcher.getGoal();
+    assert(updated_goal_1 == 123, 'Failed to update goal');
 
     start_cheat_caller_address_global(VALID_ADDRESS_2());
-    dispatcher.set_goal(140);
-    let new_goal_2 = dispatcher.get_goal();
-    assert(new_goal_2 == 140, 'Set goal method not working');
+    dispatcher.setGoal(456);
+    let updated_goal_2 = dispatcher.getGoal();
+    assert(updated_goal_2 == 456, 'Failed to update goal');
+}
+
+#[test]
+#[should_panic(expected: ("You are not the fund manager",))]
+fn test_set_goal_unauthorized() {
+    let contract_address = _setup_();
+    let dispatcher = IFundDispatcher { contract_address };
+    // Change the goal without being the fund manager
+    dispatcher.setGoal(22);
 }
 
 #[test]

--- a/contracts/tests/test_fund.cairo
+++ b/contracts/tests/test_fund.cairo
@@ -195,27 +195,28 @@ fn test_set_goal_by_admins() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
 
-    let initial_goal = dispatcher.getGoal();
+    let initial_goal = dispatcher.get_goal();
     assert(initial_goal == GOAL(), 'Initial goal is incorrect');
 
     start_cheat_caller_address_global(VALID_ADDRESS_1());
-    dispatcher.setGoal(123);
-    let updated_goal_1 = dispatcher.getGoal();
+    dispatcher.set_goal(123);
+    let updated_goal_1 = dispatcher.get_goal();
     assert(updated_goal_1 == 123, 'Failed to update goal');
 
     start_cheat_caller_address_global(VALID_ADDRESS_2());
-    dispatcher.setGoal(456);
-    let updated_goal_2 = dispatcher.getGoal();
+    dispatcher.set_goal(456);
+    let updated_goal_2 = dispatcher.get_goal();
     assert(updated_goal_2 == 456, 'Failed to update goal');
 }
 
 #[test]
-#[should_panic(expected: ("You are not the fund manager",))]
+#[should_panic(expected: ("Only Admins can set goal",))]
 fn test_set_goal_unauthorized() {
     let contract_address = _setup_();
     let dispatcher = IFundDispatcher { contract_address };
-    // Change the goal without being the fund manager
-    dispatcher.setGoal(22);
+    // Change the goal as the fund manager, which shouldnt be authorized anymore
+    start_cheat_caller_address_global(FUND_MANAGER());
+    dispatcher.set_goal(22);
 }
 
 #[test]
@@ -278,16 +279,6 @@ fn test_set_reason_unauthorized() {
     // Change the reason without being authrorized
     dispatcher.set_reason("not stored reason");
 }
-
-#[test]
-#[should_panic(expected: ("Only Admins can set goal",))]
-fn test_set_goal_unauthorized() {
-    let contract_address = _setup_();
-    let dispatcher = IFundDispatcher { contract_address };
-    // Change the goal without being the fund manager
-    dispatcher.set_goal(22);
-}
-
 
 #[test]
 #[should_panic(expected: ("You are not the owner",))]


### PR DESCRIPTION
# Pull Request

- [x] Closes #258 
- [x] Added tests (if necessary)
- [x] Run tests (not succesfully)
- [ ] Run formatting
- [ ] Commented the code

## Changes description

This PR adds a test for the set_goal method in contracts/src/fund.cairo. The new test validates that:

Only authorized addresses (VALID_ADDRESS_1 and VALID_ADDRESS_2) can call the set_goal method to set a new funding goal.
Unauthorized addresses are restricted from calling the method, ensuring the security and integrity of the fund goal-setting functionality.

## Current output

- Before: There was no test validating the new assert logic in the set_goal method.
- After: The test suite now includes comprehensive coverage for the set_goal method, ensuring only admins can call it and that unauthorized access is properly restricted.

## Time spent breakdown

- Understanding the issue and analyzing requirements: 1 hour
- Writing and debugging the test cases: 1.5 hours
- Running and validating the tests: 1 hour (this is still on work, I have an error when running the build)

## Comments

This is a draft PR, I have an error when running scarb build/ snforge test related to openzeppelin and starknet dependencies, these are the logs:

![image](https://github.com/user-attachments/assets/3b464ce9-1d0d-4b30-a2ef-d1fc5e31118a)

Also would like to know what's the cli command for formatting the code
